### PR TITLE
Enhancement: Reject invalid JSON

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -27,10 +27,19 @@ final class Printer implements PrinterInterface
      * @param bool   $unEscapeUnicode
      * @param bool   $unEscapeSlashes
      *
+     * @throws \InvalidArgumentException
+     *
      * @return string
      */
     public function print(string $original, bool $unEscapeUnicode, bool $unEscapeSlashes): string
     {
+        if (null === \json_decode($original) && JSON_ERROR_NONE !== \json_last_error()) {
+            throw new \InvalidArgumentException(\sprintf(
+                '"%s" is not valid JSON.',
+                $original
+            ));
+        }
+
         $printed = '';
         $indentLevel = 0;
         $length = \strlen($original);

--- a/test/Unit/PrinterTest.php
+++ b/test/Unit/PrinterTest.php
@@ -27,6 +27,25 @@ final class PrinterTest extends Framework\TestCase
         $this->assertClassImplementsInterface(PrinterInterface::class, Printer::class);
     }
 
+    public function testPrintRejectsInvalidJson()
+    {
+        $original = $this->faker()->realText();
+
+        $printer = new Printer();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf(
+            '"%s" is not valid JSON.',
+            $original
+        ));
+
+        $printer->print(
+            $original,
+            true,
+            true
+        );
+    }
+
     /**
      * @see https://github.com/composer/composer/blob/1.6.0/tests/Composer/Test/Json/JsonFormatterTest.php#L20-L34
      */


### PR DESCRIPTION
This PR

* [x] rejects invalid JSON from `Printer::print()`