### PR TITLE
Fix: Collapse empty arrays and objects

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -131,9 +131,11 @@ final class Printer implements PrinterInterface
              */
             if ('}' === $character || ']' === $character) {
                 --$indentLevel;
-                $previousCharacter = \substr($original, $i - 1, 1);
 
-                if ('{' !== $previousCharacter && '[' !== $previousCharacter) {
+                $trimmed = \rtrim($printed);
+                $previousNonWhitespaceCharacter = \substr($trimmed, -1);
+
+                if ('{' !== $previousNonWhitespaceCharacter && '[' !== $previousNonWhitespaceCharacter) {
                     $printed .= PHP_EOL;
 
                     for ($j = 0; $j < $indentLevel; ++$j) {
@@ -143,7 +145,7 @@ final class Printer implements PrinterInterface
                     /**
                      * Collapse empty {} and [].
                      */
-                    $printed = \rtrim($printed);
+                    $printed = $trimmed;
                 }
             }
 

--- a/test/Unit/PrinterTest.php
+++ b/test/Unit/PrinterTest.php
@@ -386,6 +386,86 @@ JSON;
         $this->assertSame($original, $printed);
     }
 
+    public function testPrintCollapsesEmptyArray()
+    {
+        $original = <<<'JSON'
+[
+
+
+
+        ]
+JSON;
+
+        $expected = <<<'JSON'
+[]
+JSON;
+
+        $printer = new Printer();
+
+        $printed = $printer->print(
+            $original,
+            true,
+            true
+        );
+
+        $this->assertSame($expected, $printed);
+    }
+
+    public function testPrintCollapsesEmptyObject()
+    {
+        $original = <<<'JSON'
+{
+
+
+
+        }
+JSON;
+
+        $expected = <<<'JSON'
+{}
+JSON;
+
+        $printer = new Printer();
+
+        $printed = $printer->print(
+            $original,
+            true,
+            true
+        );
+
+        $this->assertSame($expected, $printed);
+    }
+
+    public function testPrintCollapsesEmptyComplex()
+    {
+        $original = <<<'JSON'
+{
+            "foo":          {
+    
+    
+}   ,
+    "bar": [                                ]
+        }
+JSON;
+
+        $expected = <<<'JSON'
+{
+    "foo": {},
+    "bar": []
+}
+JSON;
+
+        $printer = new Printer();
+
+        $printed = $printer->print(
+            $original,
+            true,
+            true
+        );
+
+        $this->assertSame($expected, $printed);
+    }
+
     /**
      * @see https://github.com/zendframework/zend-json/pull/37
      */


### PR DESCRIPTION
This PR

* [x] asserts that empty arrays and objects are collapsed
* [x] determines the previous non-whitespace character by trimming what has been printed so far
  