### PR TITLE
Fix: Reject mixed tabs and spaces as indent

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -51,7 +51,7 @@ final class Printer implements PrinterInterface
             ));
         }
 
-        if (1 !== \preg_match('/^[ \t]+$/', $indent)) {
+        if (1 !== \preg_match('/^( +|\t+)$/', $indent)) {
             throw new \InvalidArgumentException(\sprintf(
                 '"%s" is not a valid indent.',
                 $indent

--- a/test/Unit/PrinterTest.php
+++ b/test/Unit/PrinterTest.php
@@ -73,8 +73,9 @@ JSON;
     public function providerInvalidIndent(): \Generator
     {
         $values = [
-            'not-whitespace' => $this->faker()->sentence,
-            'contains-line-feed' => " \n ",
+            'string-contains-line-feed' => " \n ",
+            'string-mixed-space-and-tab' => " \t",
+            'string-not-whitespace' => $this->faker()->sentence,
         ];
 
         foreach ($values as $key => $value) {


### PR DESCRIPTION
This PR

* [x] asserts that mixed space and tabs are rejected as indent values
* [x] adjusts a regular expression

Follows https://github.com/localheinz/json-normalizer/pull/69.